### PR TITLE
Update package.json - require node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "type": "git",
     "url": "https://github.com/Sickboy78/ioBroker.sureflap"
   },
+  "engines": {
+    "node": ">= 18"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "^2.5.1"
   },


### PR DESCRIPTION
As you limited testing to node 18 and 20 this adapter requires node 18 minmum. So adding an engines clause is mandatory.